### PR TITLE
Hand Detection 관련 광범위한 예외 구문 처리 

### DIFF
--- a/handDetection.py
+++ b/handDetection.py
@@ -74,7 +74,9 @@ while True:
             last_executed['previous'] = current_time
             Status = "BACK"
 
-    except:
+    except IndexError:
+        # hands not found
+        # print("ERR: hands not found")
         pass
 
     if not ret:

--- a/with_RasPi/pc_app.py
+++ b/with_RasPi/pc_app.py
@@ -3,9 +3,10 @@ from cvzone.HandTrackingModule import HandDetector
 from music_controller.music_controller import MusicControll
 import time
 import requests
+from requests.exceptions import ConnectionError
 
 #라즈베리파이 flask 서버 URL 입력
-URL = ""
+URL = "http://rasp-flask-server"
 
 last_executed = {
     'stop': 0,
@@ -75,7 +76,14 @@ while True:
             last_executed['previous'] = current_time
             Status = "BACK"
 
-    except:
+    except IndexError:
+        # hands not found
+        # print("ERR: hands not found")
+        pass
+
+    except ConnectionError:
+        # server not connected
+        print("ERR: server not connected")
         pass
 
     if not ret:

--- a/with_RasPi/pc_app.py
+++ b/with_RasPi/pc_app.py
@@ -83,7 +83,7 @@ while True:
 
     except ConnectionError:
         # server not connected
-        print("ERR: server not connected")
+        # print("ERR: server not connected")
         pass
 
     if not ret:


### PR DESCRIPTION
기존 Hand Detection 코드의 너무 광범위한 예외 처리 구문을 정확하게 다시 작성하였습니다

- `IndexError` : 탐색된 손이 없을때에는 `HandDetector.findHands()` 함수에서 손에 대한 데이터를 반환하는 리스트가 비어있으므로, 각 관절에 좌표를 구할 때에 인덱스 오류가 발생합니다.
- `requests.exceptions.ConnectionError` : `with_RasPi.pc_app.py` 스크립트에서는 명령을 실행할 때, 라즈베리파이 서버로 요청을 보냈으나 서버가 꺼져있다면 ( 또는 잘못된 링크로 연결이 되지 않았다면 ) 오류가 발생합니다.